### PR TITLE
Add missing dependencies for RHEL9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,6 @@ jobs:
           dnf install -y epel-release
           dnf config-manager --add-repo http://repository.egi.eu/sw/production/cas/1/current/repo-files/egi-trustanchors.repo
           # FIXME: Replace WLCG repo by UMD5 once available
-          dnf config-manager --add-repo https://linuxsoft.cern.ch/wlcg/wlcg-el9.repo
+          dnf install -y https://linuxsoft.cern.ch/wlcg/el9/x86_64/wlcg-repo-1.0.0-1.el9.noarch.rpm
           dnf config-manager --set-enabled crb
           dnf localinstall -y ui-*.rpm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,9 +75,9 @@ jobs:
           name: rpms9
       - name: Install generated RPMs
         run: |
-          # FIXME: remove external repo when UMD5 is available 
           dnf install -y epel-release
-          dnf install -y https://research.cs.wisc.edu/htcondor/repo/23.x/htcondor-release-current.el9.noarch.rpm
-          dnf config-manager --add-repo  http://repository.egi.eu/sw/production/cas/1/current/repo-files/egi-trustanchors.repo
+          dnf config-manager --add-repo http://repository.egi.eu/sw/production/cas/1/current/repo-files/egi-trustanchors.repo
+          # FIXME: Replace WLCG repo by UMD5 once available
+          dnf config-manager --add-repo https://linuxsoft.cern.ch/wlcg/wlcg-el9.repo
           dnf config-manager --set-enabled crb
           dnf localinstall -y ui-*.rpm

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,9 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [6.0.1]
+- Add ARC RSET, ginfo and lcg-infosites on RHEL9 (#10) (Baptiste Grenier)
+
 ## [6.0.0]
 - Added support for el9 (#6) (Andrea Manzi)
  

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,7 @@ and this project adheres to
 ## [Unreleased]
 
 ## [6.0.1]
-- Add ARC RSET, ginfo and lcg-infosites on RHEL9 (#10) (Baptiste Grenier)
+- Add ARC REST, ginfo and lcg-infosites on RHEL9 (#10) (Baptiste Grenier)
 
 ## [6.0.0]
 - Added support for el9 (#6) (Andrea Manzi)

--- a/ui.spec
+++ b/ui.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name: ui
-Version: 6.0.0
+Version: 6.0.1
 Release: 1%{?dist}
 Summary: User Interface meta-package
 Group: Applications/Internet
@@ -21,9 +21,7 @@ Requires: gfalFS
 Requires: dcache-srmclient
 Requires: lcg-ManageVOTag
 Requires: lcg-info
-Requires: lcg-infosites
 Requires: lcg-tags
-Requires: ginfo
 Requires: fts-client
 %endif
 Requires: dcap
@@ -44,14 +42,17 @@ Requires: gfal2-python3
 Requires: gfal2-util
 Requires: gfal2-doc
 Requires: gfal2-devel
+Requires: ginfo
 Requires: gsi-openssh-clients
 Requires: globus-gsi-cert-utils-progs
+Requires: lcg-infosites
 Requires: myproxy
 Requires: nordugrid-arc-client
 Requires: nordugrid-arc-plugins-xrootd
 Requires: nordugrid-arc-plugins-gfal
 Requires: nordugrid-arc-plugins-globus
 Requires: nordugrid-arc-plugins-needed
+Requires: nordugrid-arc-plugins-arcrest
 Requires: openldap-clients
 Requires: voms
 Requires: voms-clients-java
@@ -80,6 +81,8 @@ rm -rf %{buildroot}
 %doc /usr/share/doc/ui/README.md
 
 %changelog
+* Mon Jun 10 2024 <baptiste.grenier@egi.eu> - 6.0.1-1
+- Add ARC REST, ginfo and lcg-infosites on RHEL9 (#10) (Baptiste Grenier)
 * Tue Jun 04 2024 <andrea.manzi@egi.eu> - 6.0.0-1
 - Support for El9 (#6) (Andrea Manzi)
 * Fri Nov 18 2022 Baptiste Grenier <baptiste.grenier@egi.eu> - 5.0.0-1


### PR DESCRIPTION
Add missing dependencies for RHEL9, as discussed with @maarten-litmaath:
* Add ARC REST, ginfo and lcg-infosites on RHEL9
* Build and test install using WLCG https://linuxsoft.cern.ch/wlcg/el9/x86_64/, until UMD5 will be available
* Prepare version 6.0.1