### PR TITLE
Depend on CVMFS package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,7 @@ jobs:
           # FIXME: Remove htcondor and replace WLCG repo by UMD5 once available
           dnf install -y https://linuxsoft.cern.ch/wlcg/el8/x86_64/wlcg-repo-1.0.0-1.el8.noarch.rpm
           dnf install -y https://research.cs.wisc.edu/htcondor/repo/23.x/htcondor-release-current.el8.noarch.rpm
+          dnf install -y https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm
           dnf config-manager --set-enabled powertools
           dnf localinstall -y ui-*.rpm
 
@@ -103,5 +104,6 @@ jobs:
           # FIXME: Remove htcondor and replace WLCG repo by UMD5 once available
           dnf install -y https://linuxsoft.cern.ch/wlcg/el9/x86_64/wlcg-repo-1.0.0-1.el9.noarch.rpm
           dnf install -y https://research.cs.wisc.edu/htcondor/repo/23.x/htcondor-release-current.el9.noarch.rpm
+          dnf install -y https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm
           dnf config-manager --set-enabled crb
           dnf localinstall -y ui-*.rpm

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,9 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [6.2.0]
+- Include CVMFS as a dependency (#12) (Baptiste Grenier)
+
 ## [6.1.0]
 - Build and package for RHEL8 (#11) (Baptiste Grenier)
 

--- a/ui.spec
+++ b/ui.spec
@@ -10,9 +10,9 @@ URL: https://github.com/EGI-Federation/ui-metapackage
 Source: %{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-build
 
-# the above replaced by ca-policy-egi-core
 Requires: ca-policy-egi-core
 Requires: aria2
+Requires: cvmfs
 Requires: davix-libs
 Requires: fetch-crl
 Requires: condor

--- a/ui.spec
+++ b/ui.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name: ui
-Version: 6.1.0
+Version: 6.2.0
 Release: 1%{?dist}
 Summary: User Interface meta-package
 Group: Applications/Internet
@@ -81,6 +81,8 @@ rm -rf %{buildroot}
 %doc /usr/share/doc/ui/README.md
 
 %changelog
+* Tue Jun 18 2024 <baptiste.grenier@egi.eu> - 6.2.0-1
+- Include CVMFS as a dependency (#12) (Baptiste Grenier)
 * Tue Jun 11 2024 <baptiste.grenier@egi.eu> - 6.1.0-1
 - Build and package for RHEL8 (#11) (Baptiste Grenier)
 * Mon Jun 10 2024 <baptiste.grenier@egi.eu> - 6.0.1-1


### PR DESCRIPTION
* Include CVMFS as a dependency.
* Bump to 6.2.0