### PR TITLE
Stop building and releasing for CentOS 7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,28 +5,6 @@ on:
   pull_request:
 
 jobs:
-  centos7:
-    name: Build CentOS 7 RPMs
-    runs-on: ubuntu-latest
-    container: quay.io/centos/centos:7
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Install build requisites
-        run: |
-          yum install -y rpm-build rpmlint make rsync
-      - name: build rpm
-        run: |
-          make rpm
-          rpmlint --file .rpmlint.ini build/RPMS/x86_64/*.rpm
-      - name: Upload rpms
-        uses: actions/upload-artifact@v3
-        with:
-          name: rpms7
-          path: |
-            build/RPMS/x86_64/ui-*.el7.x86_64.rpm
-
   # Use a matrix for AlmaLinux version
   build-almalinux:
     strategy:
@@ -52,21 +30,6 @@ jobs:
           name: rpms${{ matrix.almalinux-version }}
           path: |
             build/RPMS/x86_64/ui-*.el${{ matrix.almalinux-version }}.x86_64.rpm
-
-  centos7-install:
-    name: Install CentOS 7 RPMs
-    needs: centos7
-    runs-on: ubuntu-latest
-    container: quay.io/centos/centos:7
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: rpms7
-      - name: Install generated RPMs
-        run: |
-          yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-          yum install -y http://repository.egi.eu/sw/production/umd/4/centos7/x86_64/updates/umd-release-4.1.3-1.el7.centos.noarch.rpm
-          yum localinstall -y ui-*.rpm
 
   install-almalinux8:
     name: Install AlmaLinux 8 RPMs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,29 +10,6 @@ on:
       - "v*"
 
 jobs:
-  centos7:
-    name: Build centOS 7 RPMs
-    runs-on: ubuntu-latest
-    container: centos:7
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: install build requisites
-        run: |
-          yum install -y rpm-build rpmlint make rsync
-      - name: build rpm
-        run: |
-          make rpm
-          rpmlint --file .rpmlint.ini build/RPMS/x86_64/*.rpm
-      - name: Upload rpms
-        uses: actions/upload-artifact@v3
-        with:
-          name: rpms7
-          path: |
-            build/RPMS/x86_64/ui-*.el7.x86_64.rpm
-            build/SRPMS/ui-*.el7.src.rpm
-
   almalinux8:
     name: Build AlmaLinux 8 RPMs
     runs-on: ubuntu-latest
@@ -76,33 +53,6 @@ jobs:
           path: |
             build/RPMS/x86_64/ui-*.el9.x86_64.rpm
             build/SRPMS/ui-*.el9.src.rpm
-
-  release7:
-    name: Upload CentOS 7 release artefacts
-    needs: centos7
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: rpms7
-
-      - name: Find package name
-        id: package_name_centos7
-        run: |
-          rpm_path=$(find . -name 'ui-*.el7.x86_64.rpm')
-          src_path=$(find . -name 'ui-*.el7.src.rpm')
-          echo "rpm_path=${rpm_path}" >> "$GITHUB_OUTPUT"
-          echo "src_path=${src_path}" >> "$GITHUB_OUTPUT"
-
-      - name: Attach CentOS 7 RPMs to the release
-        uses: softprops/action-gh-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          fail_on_unmatched_files: true
-          files: |
-            ${{ steps.package_name_centos7.outputs.rpm_path }}
-            ${{ steps.package_name_centos7.outputs.src_path }}
 
   release8:
     name: Upload AlmaLinux 8 release artefacts

--- a/README.md
+++ b/README.md
@@ -41,10 +41,14 @@ In order to help with deploying the UI, different solutions are possible:
 
   ```shell
   # Install EPEL repository
-  $ yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+  $ dnf install -y epel-release
   # Install UMD repositories, look for available UMD release on https://repository.egi.eu/
-  $ yum install -y http://repository.egi.eu/sw/production/umd/4/centos7/x86_64/updates/umd-release-4.1.3-1.el7.centos.noarch.rpm
-  $ yum localinstall -y ui-*.rpm
+  # FIXME: As of 2024-08, fall back on WLCG + upstreams repositories in place of UMD repo
+  $ dnf install -y https://linuxsoft.cern.ch/wlcg/el9/x86_64/wlcg-repo-1.0.0-1.el9.noarch.rpm
+  $ dnf install -y https://research.cs.wisc.edu/htcondor/repo/23.x/htcondor-release-current.el9.noarch.rpm
+  $ dnf install -y https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm
+  $ dnf config-manager --set-enabled crb
+  $ dnf localinstall -y ui-*.rpm
   ```
 
 - Some
@@ -163,8 +167,8 @@ $ git clone https://github.com/EGI-Federation/ui-metapackage.git
 $ cd ui-metapackage
 $ git checkout X.X.X
 # Building in a container
-$ docker run --rm -v $(pwd):/source -it quay.io/centos/centos:7
-[root@bc96d4c5a232 /]# yum install -y rpm-build make rsync rpmlint
+$ docker run --rm -v $(pwd):/source -it almalinux:9
+[root@bc96d4c5a232 /]# dnf install -y rpm-build make rsync rpmlint systemd-rpm-macros
 [root@bc96d4c5a232 /]# cd /source && make rpm
 [root@bc96d4c5a232 /]# rpmlint --file .rpmlint.ini build/RPMS/x86_64/*.rpm
 ```


### PR DESCRIPTION
* Stop building and releasing for CentOS 7.
* Update README to use AlmaLinux 9.
* Fallback on WLCG and upstream repositories until UMD 5 for AlmaLinux 9 will be available.