### PR TITLE
Remove BuildArch from ui.spec for compatibility with previous versions

### DIFF
--- a/ui.spec
+++ b/ui.spec
@@ -9,7 +9,6 @@ License: Apache-2.0
 URL: https://github.com/EGI-Federation/ui-metapackage
 Source: %{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-build
-BuildArch: noarch
 Packager: Bruce Becker <bruce.becker@egi.eu>.
 
 Requires: ca-policy-egi-core


### PR DESCRIPTION
Removed BuildArch line from ui.spec.

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
